### PR TITLE
custom permalinks not working

### DIFF
--- a/app/CustomPostTypes/SponsoredHub.php
+++ b/app/CustomPostTypes/SponsoredHub.php
@@ -56,7 +56,7 @@ class SponsoredHub {
 					'read_post' 			=> 'read_sponsored_hub',
 				),
 				'map_meta_cap' => true,
-				'rewrite' => false,
+				'rewrite' => true,
 				'query_var' => true,
 				'show_in_rest' => true,
 			);


### PR DESCRIPTION
across custom post types, this seemed to be the problem:

shortlist-digital/wp-sponsored-longform-plugin#3
shortlist-digital/wp-sponsored-post-plugin#3
https://github.com/shortlist-digital/wp-longform-plugin/pull/5